### PR TITLE
require lodash

### DIFF
--- a/index.js
+++ b/index.js
@@ -23,10 +23,10 @@ module.exports = function(sails) {
     return {
         initialize: function(done) {
             var eventsToWaitFor = [];
-            //wait for orm 
+            //wait for orm
             //and pub sub
             //to be loaded
-            //for validation to be 
+            //for validation to be
             //able to apply its patch
             if (sails.hooks.orm) {
                 eventsToWaitFor.push('hook:orm:loaded');
@@ -50,7 +50,7 @@ module.exports = function(sails) {
     //to add custom errors message
     //logic
     function patch() {
-        _(sails.models)
+        sails.util._(sails.models)
             .forEach(function(model) {
                 //bind path validate
                 //on concrete models


### PR DESCRIPTION
this fixes the issue that lodash is not in your projects package.json and also in production we run sails www and that won't go through if lodash is global. Besides that its not the beste style to have global variables.