### PR TITLE
Do not leak variables

### DIFF
--- a/lib/validateCustom.js
+++ b/lib/validateCustom.js
@@ -27,7 +27,7 @@ module.exports = function(model, validationError) {
 
     //grab field names
     //from the messages
-    validationFields = Object.keys(messages);
+    var validationFields = Object.keys(messages);
 
     //iterate over all our custom
     //defined validation messages


### PR DESCRIPTION
Also, consider using [strict mode](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Strict_mode) - you could avoid errors like these in strict mode altogether.:)