### PR TITLE
Fix errors with associations

### DIFF
--- a/lib/create.js
+++ b/lib/create.js
@@ -20,7 +20,7 @@ module.exports = function(model, validateCustom) {
     //with custom error message checking
     function create(values, callback) {
 
-        // handle Deferred where 
+        // handle Deferred where
         // it passes criteria first
         // see https://github.com/balderdashy/waterline/blob/master/lib/waterline/query/dql/create.js#L26
         if (arguments.length === 3) {
@@ -47,11 +47,15 @@ module.exports = function(model, validateCustom) {
                 if (error) {
                     //process sails ValidationError and
                     //attach Errors key in error object
-                    //as a place to lookup for our 
+                    //as a place to lookup for our
                     //custom errors messages
                     if (error.ValidationError) {
-                        error.Errors =
-                            validateCustom(model, error.ValidationError);
+                        var customError = validateCustom(model, error.ValidationError);
+
+                        // will return and override with empty object when using associations
+                        if (Object.keys(customError).length !== 0) {
+                            error.Errors = customError;
+                        }
                     }
 
                     callback(error);

--- a/lib/createEach.js
+++ b/lib/createEach.js
@@ -17,7 +17,7 @@ module.exports = function(model, validateCustom) {
 
     //prepare new createEach method
     function createEach(values, callback) {
-        // handle Deferred where 
+        // handle Deferred where
         // it passes criteria first
         // See https://github.com/balderdashy/waterline/blob/master/lib/waterline/query/aggregate.js#L27
         if (arguments.length === 3) {
@@ -44,11 +44,15 @@ module.exports = function(model, validateCustom) {
                 if (error) {
                     //process sails ValidationError and
                     //attach Errors key in error object
-                    //as a place to lookup for our 
+                    //as a place to lookup for our
                     //custom errors messages
                     if (error.ValidationError) {
-                        error.Errors =
-                            validateCustom(model, error.ValidationError);
+                        var customError = validateCustom(model, error.ValidationError);
+
+                        // will return and override with empty object when using associations
+                        if (Object.keys(customError).length !== 0) {
+                            error.Errors = customError;
+                        }
                     }
 
                     callback(error);

--- a/lib/findOrCreate.js
+++ b/lib/findOrCreate.js
@@ -35,11 +35,15 @@ module.exports = function(model, validateCustom) {
                 if (error) {
                     //process sails ValidationError and
                     //attach Errors key in error object
-                    //as a place to lookup for our 
+                    //as a place to lookup for our
                     //custom errors messages
                     if (error.ValidationError) {
-                        error.Errors =
-                            validateCustom(model, error.ValidationError);
+                        var customError = validateCustom(model, error.ValidationError);
+
+                        // will return and override with empty object when using associations
+                        if (Object.keys(customError).length !== 0) {
+                            error.Errors = customError;
+                        }
                     }
 
                     callback(error);

--- a/lib/findOrCreateEach.js
+++ b/lib/findOrCreateEach.js
@@ -36,11 +36,15 @@ module.exports = function(model, validateCustom) {
                 if (error) {
                     //process sails ValidationError and
                     //attach Errors key in error object
-                    //as a place to lookup for our 
+                    //as a place to lookup for our
                     //custom errors messages
                     if (error.ValidationError) {
-                        error.Errors =
-                            validateCustom(model, error.ValidationError);
+                        var customError = validateCustom(model, error.ValidationError);
+
+                        // will return and override with empty object when using associations
+                        if (Object.keys(customError).length !== 0) {
+                            error.Errors = customError;
+                        }
                     }
                     //hand over error
                     //to user callback

--- a/lib/update.js
+++ b/lib/update.js
@@ -38,11 +38,15 @@ module.exports = function(model, validateCustom) {
                 if (error) {
                     //process sails ValidationError and
                     //attach Errors key in error object
-                    //as a place to lookup for our 
+                    //as a place to lookup for our
                     //custom errors messages
                     if (error.ValidationError) {
-                        error.Errors =
-                            validateCustom(model, error.ValidationError);
+                        var customError = validateCustom(model, error.ValidationError);
+
+                        // will return and override with empty object when using associations
+                        if (Object.keys(customError).length !== 0) {
+                            error.Errors = customError;
+                        }
                     }
 
                     callback(error);

--- a/lib/validate.js
+++ b/lib/validate.js
@@ -21,11 +21,15 @@ module.exports = function(model, validateCustom) {
                 if (error) {
                     //process sails ValidationError and
                     //attach Errors key in error object
-                    //as a place to lookup for our 
+                    //as a place to lookup for our
                     //custom errors messages
                     if (error.ValidationError) {
-                        error.Errors =
-                            validateCustom(model, error.ValidationError);
+                        var customError = validateCustom(model, error.ValidationError);
+
+                        // will return and override with empty object when using associations
+                        if (Object.keys(customError).length !== 0) {
+                            error.Errors = customError;
+                        }
                     }
 
                     callback(error);

--- a/lib/validateCustom.js
+++ b/lib/validateCustom.js
@@ -5,7 +5,7 @@
  *
  * @descriptions process validation error and mixin user defined errors
  *               to produce friendly error messages.
- *               
+ *
  *               For this to work a model may either define `validationMessages`
  *               hash as static property or adding validation messages into
  *               locale files.
@@ -67,7 +67,7 @@ module.exports = function(model, validationError) {
                             sails.config.i18n.requestLocale ||
                             sails.config.i18n.defaultLocale;
 
-                        //grab custom error 
+                        //grab custom error
                         //message from config/locales/`locale`.json
                         var customMessage = sails.__({
                             phrase: phrase,


### PR DESCRIPTION
#18

Prevent overriding `error.Errors` when validation returns an empty object. 