### PR TITLE
Add ability to specify a property to use instead of Errors

### DIFF
--- a/lib/WLValidationError.js
+++ b/lib/WLValidationError.js
@@ -3,14 +3,21 @@
 //patch WLValidationError to allow for custom error messages
 var WLValidationError = require('sails/node_modules/waterline/lib/waterline/error/WLValidationError');
 
-//reference WLValidationError.toJSON 
+//reference WLValidationError.toJSON
 //and WLValidationError.toJSON
 var toJSON = WLValidationError.prototype.toJSON;
 
 //patch WLValidationError to add `Errors`
 WLValidationError.prototype.toJSON =
     WLValidationError.prototype.toPOJO = function() {
+        var errorKey = 'Errors';
+
+        if (sails && sails.config && sails.config.errors &&
+            typeof sails.config.errors.errorKey === 'string') {
+            errorKey = sails.config.errors.errorKey;
+        }
+
         var asJSON = toJSON.call(this);
-        asJSON.Errors = this.Errors;
+        asJSON[errorKey] = this.Errors;
         return asJSON;
     };

--- a/test/validation.spec.js
+++ b/test/validation.spec.js
@@ -38,6 +38,24 @@ describe('Hook#validation', function() {
             });
     });
 
+    it('should be able to serialize custom errors when toPOJO is invoked and use custom Errors key', function(done) {
+        sails.config.errors = {
+          errorKey: 'customErrors'
+        };
+
+        User
+            .create({}, function(error, user) {
+
+                var asPOJO = error.toPOJO();
+
+                expect(asPOJO.customErrors).to.exist;
+
+                delete sails.config.errors;
+
+                done(null, user);
+            });
+    });
+
     it('should throw custom errors', function(done) {
         User
             .create({}, function(error, user) {


### PR DESCRIPTION
I've added the ability to override the default property the custom error messages output to.