### PR TITLE
fixed bug columnName

### DIFF
--- a/lib/validateCustom.js
+++ b/lib/validateCustom.js
@@ -38,7 +38,15 @@ module.exports = function(model, validationError) {
 
             //grab field errors from the
             //sails validation error hash
-            var fieldErrors = validationError[validationField];
+            //if sails is connected to a database a user can declare a column name
+            //the valid sails validation error will use the column name as property
+            var fieldErrors;
+            if (model._attributes[validationField].columnName) {
+                fieldErrors = validationError[model._attributes[validationField].columnName];
+            }
+            else {
+                fieldErrors = validationError[validationField];
+            }
 
             //is there any field
             //error(s) found in ValidationError


### PR DESCRIPTION
Hey,

I realized that when you declare a columnName in the models attribute, the validation doesn't work because the sails validation error will return the columnName as key in the object.

I couldn't make a test because you need a database for this. Without a database the columnName will be ignored.

You can test it if you install postgres + sails-postgres, add connection to the test bootstrap and add property columnName: email_address to the user model.
