### PR TITLE
[FIX] Removing relative requires for waterline modules

### DIFF
--- a/lib/WLValidationError.js
+++ b/lib/WLValidationError.js
@@ -1,7 +1,7 @@
 'use strict';
 
 //patch WLValidationError to allow for custom error messages
-var WLValidationError = require('sails/node_modules/waterline/lib/waterline/error/WLValidationError');
+var WLValidationError = require('waterline/lib/waterline/error/WLValidationError');
 
 //reference WLValidationError.toJSON
 //and WLValidationError.toJSON

--- a/lib/create.js
+++ b/lib/create.js
@@ -2,7 +2,7 @@
 
 //dependencies
 //import sails waterline Deferred
-var Deferred = require('sails/node_modules/waterline/lib/waterline/query/deferred');
+var Deferred = require('waterline/lib/waterline/query/deferred');
 
 
 /**

--- a/lib/createEach.js
+++ b/lib/createEach.js
@@ -2,7 +2,7 @@
 
 //dependencies
 //import sails waterline Deferred
-var Deferred = require('sails/node_modules/waterline/lib/waterline/query/deferred');
+var Deferred = require('waterline/lib/waterline/query/deferred');
 
 /**
  * @description path sails `createEach()` method to allow

--- a/lib/findOrCreate.js
+++ b/lib/findOrCreate.js
@@ -2,7 +2,7 @@
 
 //dependencies
 //import sails waterline Deferred
-var Deferred = require('sails/node_modules/waterline/lib/waterline/query/deferred');
+var Deferred = require('waterline/lib/waterline/query/deferred');
 
 /**
  * @description path sails `findOrCreate()` method to allow

--- a/lib/findOrCreateEach.js
+++ b/lib/findOrCreateEach.js
@@ -2,7 +2,7 @@
 
 //dependencies
 //import sails waterline Deferred
-var Deferred = require('sails/node_modules/waterline/lib/waterline/query/deferred');
+var Deferred = require('waterline/lib/waterline/query/deferred');
 
 /**
  * @deprecated See https://github.com/balderdashy/waterline/pull/843

--- a/lib/update.js
+++ b/lib/update.js
@@ -2,7 +2,7 @@
 
 //dependencies
 //import sails waterline Deferred
-var Deferred = require('sails/node_modules/waterline/lib/waterline/query/deferred');
+var Deferred = require('waterline/lib/waterline/query/deferred');
 
 /**
  * @description path sails `update()` method to allow

--- a/package.json
+++ b/package.json
@@ -68,5 +68,8 @@
         "sails": "^0.11.2",
         "sails-disk": "^0.10.8",
         "supertest": "^1.1.0"
+    },
+    "dependencies": {
+        "waterline": "^0.10.28"
     }
 }


### PR DESCRIPTION
Relative requires via the node_modules/sails causes the dependencies to
break in newer versions as they follow a flat structured `node_modules`