### PR TITLE
fixed "Cannot read property "call" of undefined" for error E_UNKNOWN

### DIFF
--- a/lib/WLValidationError.js
+++ b/lib/WLValidationError.js
@@ -17,6 +17,10 @@ module.exports.patch = function(error) {
             errorKey = sails.config.errors.errorKey;
         }
 
+        if (!toJSON) {
+            toJSON = WLError.prototype.toJSON;
+        }
+
         var asJSON = toJSON.call(this);
         asJSON[errorKey] = this.Errors;
         return asJSON;


### PR DESCRIPTION
if you try to JSON.stringify for E_UNKNOWN error it will crached with  "Cannot read property "call" of undefined"
