### PR TITLE
Made change to support the meta._req object for precise Locale per request

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,19 +1,17 @@
 sails-hook-validation
 =====================
 
-[![Build Status](https://travis-ci.org/lykmapipo/sails-hook-validation.svg?branch=master)](https://travis-ci.org/lykmapipo/sails-hook-validation)
+[![Build Status](https://travis-ci.org/fpm-git/sails-hook-validation.svg?branch=master)](https://travis-ci.org/fpm-git/sails-hook-validation)
 
 Custom validation error messages for sails model with i18n support. Its works with `callback`, `deferred` and `promise` style `model API` provided with sails.
 
 *Note:* 
-- *This requires Sails v0.11.0+.  If v0.11.0+ isn't published to NPM yet, you'll need to install it via Github.*
 - *`sails-hook-validation` work by patch model static `validate()`, `create()`, `createEach()`, `findOrCreate()`, `findOrCreateEach()` and `update()`.*
-- *To have custom error messages at model instance level consider using [sails-model-new](https://github.com/lykmapipo/sails-model-new).*
 - *`sails-hook-validation` opt to use `error.Errors` and not to re-create or remove any properties of error object so as to remain with sails legacy options*
 
 ## Installation
 ```sh
-$ npm install --save sails-hook-validation
+$ npm install --save '@floatplane/sails-hook-validation'
 ```
 
 ## Usage

--- a/lib/create.js
+++ b/lib/create.js
@@ -4,7 +4,6 @@
 //import sails waterline Deferred
 var Deferred = require('waterline/lib/waterline/query/deferred');
 var WLValidationError = require('./WLValidationError');
-var _ = require('lodash');
 
 /**
  * @description path sails `create()` method to allow
@@ -28,7 +27,7 @@ module.exports = function(model, validateCustom) {
         // handle Deferred where
         // it passes criteria first
         // see https://github.com/balderdashy/waterline/blob/master/lib/waterline/query/dql/create.js#L26
-        if(_.isPlainObject(arguments[0]) && (_.isPlainObject(arguments[1]) || _.isArray(arguments[1]))) {
+        if((_ || sails.util._).isPlainObject(arguments[0]) && ((_ || sails.util._).isPlainObject(arguments[1]) || (_ || sails.util._).isArray(arguments[1]))) {
             values = arguments[1];
             callback = arguments[2];
         }

--- a/lib/create.js
+++ b/lib/create.js
@@ -4,6 +4,7 @@
 //import sails waterline Deferred
 var Deferred = require('waterline/lib/waterline/query/deferred');
 var WLValidationError = require('./WLValidationError');
+var _ = require('lodash');
 
 /**
  * @description path sails `create()` method to allow
@@ -21,15 +22,15 @@ module.exports = function(model, validateCustom) {
     //prepare new create method
     //which wrap sailsCreate
     //with custom error message checking
-    function create(values, callback) {
-
+    function create(values, callback, meta) {
+        if (!meta) { meta = {}; }
+        
         // handle Deferred where
         // it passes criteria first
         // see https://github.com/balderdashy/waterline/blob/master/lib/waterline/query/dql/create.js#L26
-        if (arguments.length === 3) {
-            var args = Array.prototype.slice.call(arguments);
-            callback = args.pop();
-            values = args.pop();
+        if(_.isPlainObject(arguments[0]) && (_.isPlainObject(arguments[1]) || _.isArray(arguments[1]))) {
+            values = arguments[1];
+            callback = arguments[2];
         }
 
         // return Deferred
@@ -54,7 +55,7 @@ module.exports = function(model, validateCustom) {
                     //custom errors messages
                     if (error.invalidAttributes) {
                         var customError =
-                            validateCustom(model, error.invalidAttributes);
+                            validateCustom(model, error.invalidAttributes, meta._req);
 
                         // will return and override with empty object
                         // when using associations

--- a/lib/createEach.js
+++ b/lib/createEach.js
@@ -25,7 +25,7 @@ module.exports = function(model, validateCustom) {
         // handle Deferred where
         // it passes criteria first
         // See https://github.com/balderdashy/waterline/blob/master/lib/waterline/query/aggregate.js#L27
-        if(_.isPlainObject(arguments[0]) && (_.isPlainObject(arguments[1]) || _.isArray(arguments[1]))) {
+        if((_ || sails.util._).isPlainObject(arguments[0]) && ((_ || sails.util._).isPlainObject(arguments[1]) || (_ || sails.util._).isArray(arguments[1]))) {
             values = arguments[1];
             callback = arguments[2];
         }

--- a/lib/createEach.js
+++ b/lib/createEach.js
@@ -19,14 +19,15 @@ module.exports = function(model, validateCustom) {
     var sailsCreate = model.createEach;
 
     //prepare new createEach method
-    function createEach(values, callback) {
+    function createEach(values, callback, meta) {
+        if (!meta) { meta = {}; }
+
         // handle Deferred where
         // it passes criteria first
         // See https://github.com/balderdashy/waterline/blob/master/lib/waterline/query/aggregate.js#L27
-        if (arguments.length === 3) {
-            var args = Array.prototype.slice.call(arguments);
-            callback = args.pop();
-            values = args.pop();
+        if(_.isPlainObject(arguments[0]) && (_.isPlainObject(arguments[1]) || _.isArray(arguments[1]))) {
+            values = arguments[1];
+            callback = arguments[2];
         }
 
         // return Deferred
@@ -51,7 +52,7 @@ module.exports = function(model, validateCustom) {
                     //custom errors messages
                     if (error.invalidAttributes) {
                         var customError =
-                            validateCustom(model, error.invalidAttributes);
+                            validateCustom(model, error.invalidAttributes, meta._req);
 
                         // will return and override with empty object
                         // when using associations

--- a/lib/findOrCreate.js
+++ b/lib/findOrCreate.js
@@ -19,7 +19,9 @@ module.exports = function(model, validateCustom) {
     var sailsFindOrCreate = model.findOrCreate;
 
     //prepare new findOrCreate method
-    function findOrCreate(criteria, values, callback) {
+    function findOrCreate(criteria, values, callback, meta) {
+        if (!meta) { meta = {}; }
+
         // return Deferred
         // if no callback passed
         // See https://github.com/balderdashy/waterline/blob/master/lib/waterline/query/composite.js#L43
@@ -42,7 +44,7 @@ module.exports = function(model, validateCustom) {
                     //custom errors messages
                     if (error.invalidAttributes) {
                         var customError =
-                            validateCustom(model, error.invalidAttributes);
+                            validateCustom(model, error.invalidAttributes, meta._req);
 
                         // will return and override with empty object when using associations
                         if (Object.keys(customError).length !== 0) {

--- a/lib/findOrCreateEach.js
+++ b/lib/findOrCreateEach.js
@@ -20,7 +20,9 @@ module.exports = function(model, validateCustom) {
     var sailsFindOrCreateEach = model.findOrCreateEach;
 
     //prepare new findOrCreateEach method
-    function findOrCreateEach(criterias, values, callback) {
+    function findOrCreateEach(criterias, values, callback, meta) {
+        if (!meta) { meta = {}; }
+
         // return Deferred
         // if no callback passed
         // See https://github.com/balderdashy/waterline/blob/master/lib/waterline/query/aggregate.js#L96
@@ -43,7 +45,7 @@ module.exports = function(model, validateCustom) {
                     //custom errors messages
                     if (error.invalidAttributes) {
                         var customError =
-                            validateCustom(model, error.invalidAttributes);
+                            validateCustom(model, error.invalidAttributes, meta._req);
 
                         // will return and override with empty object
                         // when using associations

--- a/lib/update.js
+++ b/lib/update.js
@@ -21,7 +21,8 @@ module.exports = function(model, validateCustom) {
     //prepare new update method
     //which wrap sailsUpdate
     //with custom error message checking
-    function update(criterias, values, callback) {
+    function update(criterias, values, callback, meta) {
+        if (!meta) { meta = {}; }
 
         // return Deferred
         // if no callback passed
@@ -45,7 +46,7 @@ module.exports = function(model, validateCustom) {
                     //custom errors messages
                     if (error.invalidAttributes) {
                         var customError =
-                            validateCustom(model, error.invalidAttributes);
+                            validateCustom(model, error.invalidAttributes, meta._req);
 
                         // will return and override with empty object
                         // when using associations

--- a/lib/validate.js
+++ b/lib/validate.js
@@ -16,7 +16,9 @@ module.exports = function(model, validateCustom) {
     var sailsValidate = model.validate;
 
     //prepare new validation method
-    function validate(values, presentOnly, callback) {
+    function validate(values, presentOnly, callback, meta) {
+        if (!meta) { meta = {}; }
+        
         if(typeof presentOnly === 'function'){
             callback = presentOnly;
             presentOnly = null;
@@ -33,7 +35,7 @@ module.exports = function(model, validateCustom) {
                     //custom errors messages
                     if (error.invalidAttributes) {
                         var customError =
-                            validateCustom(model, error.invalidAttributes);
+                            validateCustom(model, error.invalidAttributes, meta._req);
 
                         // will return and override with empty object
                         // when using associations

--- a/lib/validateCustom.js
+++ b/lib/validateCustom.js
@@ -13,11 +13,11 @@
  *
  * @param {Object} model valid sails model definition
  * @param {Object} invalidAttributes a valid sails validation error object.
+ * @param {Object} [req] a request object - It's necessary to get the exact locale
  *
  * @returns {Object} an object with friendly validation error conversions.
  */
-module.exports = function(model, invalidAttributes) {
-
+module.exports = function(model, invalidAttributes, req) {
     //grab model validations definitions
     var validations = model._validator.validations || {};
 
@@ -70,8 +70,8 @@ module.exports = function(model, invalidAttributes) {
 
                         if(sails.config.i18n){                            
                             //deduce locale from request else
-                            //use default locale
-                            locale =
+                            //use default locale from config
+                            locale = (typeof req !== 'undefined' && req.getLocale !== 'undefined') ? req.getLocale() : 
                                 sails.config.i18n.requestLocale ||
                                 sails.config.i18n.defaultLocale;  
                             

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-    "name": "sails-hook-validation",
+    "name": "@floatplane/sails-hook-validation",
     "version": "0.5.0",
     "description": "Custom validation error messages for sails model with i18n support",
     "main": "index.js",
@@ -12,7 +12,7 @@
     },
     "repository": {
         "type": "git",
-        "url": "https://github.com/lykmapipo/sails-hook-validation.git"
+        "url": "https://github.com/fpm-git/sails-hook-validation.git"
     },
     "keywords": [
         "sails",
@@ -41,9 +41,9 @@
     },
     "license": "MIT",
     "bugs": {
-        "url": "https://github.com/lykmapipo/sails-hook-validation/issues"
+        "url": "https://github.com/fpm-git/sails-hook-validation/issues"
     },
-    "homepage": "https://github.com/lykmapipo/sails-hook-validation",
+    "homepage": "https://github.com/fpm-git/sails-hook-validation",
     "contributors": [{
         "name": "lykmapipo",
         "github": "https://github.com/lykmapipo"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "sails-hook-validation",
-    "version": "0.4.7",
+    "version": "0.5.0",
     "description": "Custom validation error messages for sails model with i18n support",
     "main": "index.js",
     "sails": {


### PR DESCRIPTION
This is to actually fix https://github.com/lykmapipo/sails-hook-validation/issues/34

I've made a test where I had a policy that had a setTimeout for 3 seconds before actually going forward to the controller. I tried calling the route with a header "accept-language: en" and before the timeout actually finished, I tried doing the same request with a different accept-language value and the result from the first request would the return in the language of the last request accept-language header value.

This fix is kind of a last resort but I was not sure how to implement it while keeping the same transparent implementation. Instead, I used the "metaContainer" value that is usually found has the 3rd parameter for the different methods and if you populate it with `{ _req: req }`, it will use the request locale, else if meta._req is not populated, it will fallback to the old method. 

I've also changed the "handle deferred where" piece of code because it wouldn't work with the current implementation and just ported the code block from the sails 0.12 codebase.

I might also create some additional tests to prove my point and also check that it's not breaking the default implementation of all the model methods.