### PR TITLE
Option to disable i18n translation

### DIFF
--- a/index.js
+++ b/index.js
@@ -61,6 +61,9 @@ module.exports = function(sails) {
         });
     }
 
+    if (sails.config.i18n.hookValidation == undefined)
+	    sails.config.i18n.hookValidation = true;
+
     //export hook definition
     return {
         //intercent all request and current grab request locale
@@ -77,7 +80,6 @@ module.exports = function(sails) {
                 }
             }
         },
-
         initialize: function(done) {
             var eventsToWaitFor = [];
 

--- a/index.js
+++ b/index.js
@@ -61,7 +61,7 @@ module.exports = function(sails) {
         });
     }
 
-    if (sails.config.i18n.hookValidation === undefined) {
+    if (sails.config.i18n && sails.config.i18n.hookValidation === undefined) {
         sails.config.i18n.hookValidation = true;
     }
 

--- a/index.js
+++ b/index.js
@@ -61,8 +61,9 @@ module.exports = function(sails) {
         });
     }
 
-    if (sails.config.i18n.hookValidation == undefined)
-	    sails.config.i18n.hookValidation = true;
+    if (sails.config.i18n.hookValidation === undefined) {
+        sails.config.i18n.hookValidation = true;
+    }
 
     //export hook definition
     return {

--- a/lib/validateCustom.js
+++ b/lib/validateCustom.js
@@ -68,13 +68,13 @@ module.exports = function(model, invalidAttributes) {
                         var customMessage = phrase;
                         var locale;
 
-                        if(sails.config.i18n){                            
+                        if(sails.config.i18n && sails.config.i18n.hookValidation){
                             //deduce locale from request else
                             //use default locale
                             locale =
                                 sails.config.i18n.requestLocale ||
-                                sails.config.i18n.defaultLocale;  
-                            
+                                sails.config.i18n.defaultLocale;
+
                             if(locale){
                                 //grab custom error
                                 //message from config/locales/`locale`.json

--- a/package.json
+++ b/package.json
@@ -1,75 +1,85 @@
 {
-    "name": "sails-hook-validation",
-    "version": "0.4.7",
-    "description": "Custom validation error messages for sails model with i18n support",
-    "main": "index.js",
-    "sails": {
-        "isHook": true
+  "name": "sails-hook-validation",
+  "version": "0.4.7",
+  "description": "Custom validation error messages for sails model with i18n support",
+  "main": "index.js",
+  "sails": {
+    "isHook": true
+  },
+  "scripts": {
+    "pretest": "npm link && npm link sails-hook-validation",
+    "test": "grunt test"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/lykmapipo/sails-hook-validation.git"
+  },
+  "keywords": [
+    "sails",
+    "sails-hook",
+    "model",
+    "validator",
+    "validation",
+    "validate",
+    "custom",
+    "messages",
+    "define",
+    "database",
+    "exceptions",
+    "constraints",
+    "i18n",
+    "internationalization",
+    "hook",
+    "plugin",
+    "error",
+    "module"
+  ],
+  "author": {
+    "name": "lykmapipo",
+    "email": "lallyelias87@gmail.com",
+    "url": "https://github.com/lykmapipo"
+  },
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/lykmapipo/sails-hook-validation/issues"
+  },
+  "homepage": "https://github.com/lykmapipo/sails-hook-validation",
+  "contributors": [
+    {
+      "name": "lykmapipo",
+      "github": "https://github.com/lykmapipo"
     },
-    "scripts": {
-        "pretest": "npm link && npm link sails-hook-validation",
-        "test": "grunt test"
+    {
+      "name": "isery",
+      "github": "https://github.com/isery"
     },
-    "repository": {
-        "type": "git",
-        "url": "https://github.com/lykmapipo/sails-hook-validation.git"
+    {
+      "name": "Alaneor",
+      "github": "https://github.com/Alaneor"
     },
-    "keywords": [
-        "sails",
-        "sails-hook",
-        "model",
-        "validator",
-        "validation",
-        "validate",
-        "custom",
-        "messages",
-        "define",
-        "database",
-        "exceptions",
-        "constraints",
-        "i18n",
-        "internationalization",
-        "hook",
-        "plugin",
-        "error",
-        "module"
-    ],
-    "author": {
-        "name": "lykmapipo",
-        "email": "lallyelias87@gmail.com",
-        "url": "https://github.com/lykmapipo"
-    },
-    "license": "MIT",
-    "bugs": {
-        "url": "https://github.com/lykmapipo/sails-hook-validation/issues"
-    },
-    "homepage": "https://github.com/lykmapipo/sails-hook-validation",
-    "contributors": [{
-        "name": "lykmapipo",
-        "github": "https://github.com/lykmapipo"
-    }, {
-        "name": "isery",
-        "github": "https://github.com/isery"
-    }, {
-        "name": "Alaneor",
-        "github": "https://github.com/Alaneor"
-    }, {
-        "name": "VMBindraban",
-        "github": "https://github.com/VMBindraban"
-    }],
-    "devDependencies": {
-        "chai": "^2.3.0",
-        "faker": "^2.1.5",
-        "grunt": "^0.4.5",
-        "grunt-contrib-jshint": "^0.11.3",
-        "grunt-mocha-test": "^0.12.7",
-        "jshint-stylish": "^1.0.2",
-        "mocha": "^2.4.5",
-        "sails": "^0.11.2",
-        "sails-disk": "^0.10.8",
-        "supertest": "^1.1.0"
-    },
-    "dependencies": {
-        "waterline": "^0.10.31"
+    {
+      "name": "VMBindraban",
+      "github": "https://github.com/VMBindraban"
     }
+  ],
+  "devDependencies": {
+    "chai": "^2.3.0",
+    "faker": "^2.1.5",
+    "grunt": "^0.4.5",
+    "grunt-contrib-jshint": "^0.11.3",
+    "grunt-mocha-test": "^0.12.7",
+    "jshint-stylish": "^1.0.2",
+    "mocha": "^2.4.5",
+    "sails": "^0.11.2",
+    "sails-disk": "^0.10.8",
+    "supertest": "^1.1.0"
+  },
+  "dependencies": {
+    "anchor": "^1.3.0",
+    "async": "^2.6.1",
+    "bluebird": "^3.5.3",
+    "lodash": "^4.17.11",
+    "prompt": "^1.0.0",
+    "waterline": "^0.10.31"
+  }
 }


### PR DESCRIPTION
Hi,

My app needs to include the threshold into the message on validation error. 
(eg. "Name should be within 15 characters.")
In the case of the message above, the code can be written like this:

```javascript
req.__('Name should be within %s characters.', User.attributes.name.maxLength);
```

But sails-hook-validation translate the message inside when the current or default locale is set.
This behavior disturbs to replace the specifier in the message with the value.
The reason is:

  * Due to that behavior, I don't know what model (and field) the message is for.
  * I can't get the threshold because the name of the model (and the field) is not known.

So I added the option to disable i18n translation in the hook.
Using this option, I can receive the raw customMessage (formated as "model.field.rule').

Please pull them if acceptable.